### PR TITLE
🩹 Fix PWA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,6 @@ jobs:
         run: |
           python -m pip install -U pip wheel
           python -m pip install -r utils/requirements.txt
-          python -m pip install Pygments
 
       - name: Build Github-Pages
         run: |
@@ -54,7 +53,7 @@ jobs:
 
       - name: Show index.html
         run: |
-          pygmentize deploy/index.html | less -R
+          python utils/post_build.py pretty-print
 
       - name: Upload bundled page
         if: success()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,11 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14.x'
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
       - name: Setup npm cache
         uses: actions/cache@v2
         with:
@@ -33,16 +38,23 @@ jobs:
           key: npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             npm-
-      - name: Install dependencies
+      - name: Install npm dependencies
         run: |
           npm ci
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install -U pip wheel
+          python -m pip install -r utils/requirements.txt
+          python -m pip install Pygments
+
       - name: Build Github-Pages
         run: |
           npm run gh-pages
 
       - name: Show index.html
         run: |
-          cat deploy/index.html
+          pygmentize deploy/index.html | less -R
 
       - name: Upload bundled page
         if: success()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,10 @@ jobs:
         run: |
           npm run gh-pages
 
+      - name: Show index.html
+        run: |
+          cat deploy/index.html
+
       - name: Upload bundled page
         if: success()
         uses: actions/upload-artifact@v2

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "parcel:gh-pages": "parcel build src/index2.html --dist-dir deploy --no-source-maps --public-url https://s-weigand.github.io/dev-emoji-page/",
     "build:sw-dev": "workbox generateSW workbox-configs/dev.js --watch",
     "build:sw-prod": "workbox generateSW workbox-configs/prod.js",
-    "gh-pages": "run-s clean parcel:gh-pages build:sw-prod move-index2",
+    "gh-pages": "run-s clean parcel:gh-pages build:sw-prod post_process:gh-pages",
     "move-index2": "mv deploy/index2.html deploy/index.html",
+    "post_process:gh-pages": "python utils/post_build.py",
     "clean": "run-s clean:del clean:mkdir",
     "clean:mkdir": "mkdir dist deploy",
     "clean:del": "rimraf dist deploy .parcel-cache"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build:sw-prod": "workbox generateSW workbox-configs/prod.js",
     "gh-pages": "run-s clean parcel:gh-pages build:sw-prod post_process:gh-pages",
     "move-index2": "mv deploy/index2.html deploy/index.html",
-    "post_process:gh-pages": "python utils/post_build.py",
+    "post_process:gh-pages": "python utils/post_build.py fix-index-html",
     "clean": "run-s clean:del clean:mkdir",
     "clean:mkdir": "mkdir dist deploy",
     "clean:del": "rimraf dist deploy .parcel-cache"

--- a/utils/post_build.py
+++ b/utils/post_build.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+
+
+deploy_dir = Path(__file__).parent.parent / "deploy"
+src_file = deploy_dir / "index2.html"
+
+public_url = r"https://s-weigand.github.io/dev-emoji-page"
+
+soup = BeautifulSoup(src_file.read_text(), features="lxml")
+
+for meta_tag in soup.select("meta,link"):
+    if meta_tag.has_attr("content") and meta_tag["content"].startswith("/"):
+        meta_tag["content"] = f"{public_url}{meta_tag['content']}"
+
+    elif meta_tag.has_attr("href") and meta_tag["href"].startswith("/"):
+        meta_tag["href"] = f"{public_url}{meta_tag['href']}"
+
+dest_file = deploy_dir / "index.html"
+
+dest_file.write_text(str(soup))
+src_file.unlink(missing_ok=True)

--- a/utils/post_build.py
+++ b/utils/post_build.py
@@ -3,23 +3,43 @@
 from pathlib import Path
 
 from bs4 import BeautifulSoup
+from pygments import highlight
+from pygments.lexers.html import HtmlLexer
+from pygments.formatters.terminal import TerminalFormatter
+from yaargh import ArghParser
 
 
-deploy_dir = Path(__file__).parent.parent / "deploy"
-src_file = deploy_dir / "index2.html"
+DEPLOY_DIR = Path(__file__).parent.parent / "deploy"
+SRC_FILE = DEPLOY_DIR / "index2.html"
+DEST_FILE = DEPLOY_DIR / "index.html"
 
-public_url = r"https://s-weigand.github.io/dev-emoji-page"
 
-soup = BeautifulSoup(src_file.read_text(), features="lxml")
+def fix_index_html():
+    """Fixes reprent public url to links and rename file."""
+    public_url = r"https://s-weigand.github.io/dev-emoji-page"
 
-for meta_tag in soup.select("meta,link"):
-    if meta_tag.has_attr("content") and meta_tag["content"].startswith("/"):
-        meta_tag["content"] = f"{public_url}{meta_tag['content']}"
+    soup = BeautifulSoup(SRC_FILE.read_text(), features="lxml")
 
-    elif meta_tag.has_attr("href") and meta_tag["href"].startswith("/"):
-        meta_tag["href"] = f"{public_url}{meta_tag['href']}"
+    for meta_tag in soup.select("meta,link"):
+        if meta_tag.has_attr("content") and meta_tag["content"].startswith("/"):
+            meta_tag["content"] = f"{public_url}{meta_tag['content']}"
 
-dest_file = deploy_dir / "index.html"
+        elif meta_tag.has_attr("href") and meta_tag["href"].startswith("/"):
+            meta_tag["href"] = f"{public_url}{meta_tag['href']}"
 
-dest_file.write_text(str(soup))
-src_file.unlink(missing_ok=True)
+    DEST_FILE.write_text(str(soup))
+    SRC_FILE.unlink(missing_ok=True)
+
+
+def pretty_print():
+    """pretttyprint html in the terminal"""
+    pretty_html = BeautifulSoup(DEST_FILE.read_text(), features="lxml").prettify()
+    print(highlight(pretty_html, HtmlLexer(), TerminalFormatter()))
+
+
+parser = ArghParser()
+parser.add_commands([fix_index_html, pretty_print])
+
+
+if __name__ == "__main__":
+    parser.dispatch()

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4
+lxml

--- a/utils/requirements.txt
+++ b/utils/requirements.txt
@@ -1,2 +1,4 @@
 beautifulsoup4
 lxml
+yaargh
+Pygments


### PR DESCRIPTION
Fixes the broken paths to the PWA links because `public-url` wasn't prefixed.
Also adds a pretty printer for the generated HTML to the gh-action workflow.