### PR TITLE
🚇⚙️ Don't run CI on push to dependabot branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Dependabot opens a PR anyway, not need to run the CI twice.