### PR TITLE
🩹 Fix service worker fallback causes bad URL throws error

### DIFF
--- a/workbox-configs/prod.js
+++ b/workbox-configs/prod.js
@@ -6,6 +6,6 @@ module.exports = {
   skipWaiting: true,
   sourcemap: false,
   mode: "production",
-  navigateFallback: "dev-emoji-page/index.html",
+  navigateFallback: "index.html",
   runtimeCaching: [{ urlPattern: "*", handler: "NetworkFirst" }],
 };


### PR DESCRIPTION
Seems like the workbox service worker had a change and now generates a cache URL `https://s-weigand.github.io/dev-emoji-page/dev-emoji-page/index.html` instead of `https://s-weigand.github.io/dev-emoji-page/index.html`.
This causes `createHandlerBoundToRUL` in the generated service worker code to throw an error.

<img width="720" height="206" alt="image" src="https://github.com/user-attachments/assets/9b7a1229-762e-4807-9a21-fd701541459f" />
